### PR TITLE
Refresh MMath public export pages for RC state

### DIFF
--- a/scripts/sync-public-release-pages.sh
+++ b/scripts/sync-public-release-pages.sh
@@ -4,7 +4,7 @@ set -eu
 SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
 
-PROJECTS_PUBLIC_PAGES_DIR="$HOME/Projects/public"
+PROJECTS_PUBLIC_PAGES_DIR="$HOME/Projects-All/public"
 LEGACY_PUBLIC_PAGES_DIR="/Users/stevenwoods/GitPages/public"
 ICLOUD_PUBLIC_PAGES_DIR="/Users/stevenwoods/Library/Mobile Documents/com~apple~CloudDocs/StevenWoods/public"
 
@@ -132,7 +132,7 @@ cat >"$PUBLIC_STATUS_FILE" <<EOF
   "status_label": "Current release",
   "status_value": "$version",
   "focus_label": "Current focus",
-  "focus_value": "Hanoi-4 extension benchmark"
+  "focus_value": "Portability hardening and disciplined post-RC continuation"
 }
 EOF
 

--- a/site/mmath-renovation-public-page.html
+++ b/site/mmath-renovation-public-page.html
@@ -250,22 +250,22 @@
             <div class="meta">
                 <div class="metaCard">
                     <span class="metaLabel">Current Track</span>
-                    <span class="metaValue">0.10.x</span>
-                    <div class="metaNote">Late beta with strong historical reproduction on the core operator-style baseline.</div>
+                    <span class="metaValue">1.0 RC hardening</span>
+                    <div class="metaNote">The release-candidate restoration baseline is frozen while portability, handoff clarity, and post-RC continuation discipline are hardened.</div>
                 </div>
                 <div class="metaCard">
                     <span class="metaLabel">Build Line</span>
-                    <span class="metaValue">0.10.0-beta.1</span>
-                    <div class="metaNote">Named pre-release checkpoint with unified harness, release dashboard, and formal validation set.</div>
+                    <span class="metaValue">1.0.0-rc.1</span>
+                    <div class="metaNote">Named release-candidate checkpoint with unified harness, release dashboard, and formal validation set.</div>
                 </div>
                 <div class="metaCard">
                     <span class="metaLabel">Current Focus</span>
-                    <span class="metaValue">Hanoi-4 extension case</span>
-                    <div class="metaNote">Lower Hanoi families are aligned; the main open benchmark is the historically grounded four-disk extension.</div>
+                    <span class="metaValue">Portability hardening and disciplined post-RC continuation</span>
+                    <div class="metaNote">Keep the repo safe to continue from a fresh non-iCloud clone while the open Hanoi-4 lane stays clearly bounded.</div>
                 </div>
                 <div class="metaCard">
                     <span class="metaLabel">Updated</span>
-                    <span class="metaValue">March 22, 2026</span>
+                    <span class="metaValue">May 4, 2026</span>
                     <div class="metaNote">Public page and remote experiment links now sync from the main repository release process.</div>
                 </div>
             </div>
@@ -320,7 +320,7 @@
                 <a class="button" href="mmath-thesis.pdf">MMath thesis PDF</a>
                 <a class="button" href="mmath-thesis.ps">MMath thesis PS</a>
             </div>
-            <p class="footer">Public summary synced to the repository status on March 22, 2026.</p>
+            <p class="footer">Public summary synced to the repository status on May 4, 2026.</p>
         </section>
     </main>
 </body>

--- a/site/mmath-renovation-release-dashboard.html
+++ b/site/mmath-renovation-release-dashboard.html
@@ -279,24 +279,24 @@
     <section class="hero">
       <h1>AbTweak Restoration</h1>
       <p>One restored experimental environment for the historical AbTweak code line, with exact lower-Hanoi reproduction, broad operator-style coverage, and a disciplined path toward closing or explaining the remaining four-disk benchmark gap.</p>
-      <div class="meta">
-        <div class="metaCard">
+        <div class="meta">
+          <div class="metaCard">
           <span class="metaLabel">Target</span>
           <span class="metaValue">1.0.0</span>
-        </div>
-        <div class="metaCard">
+          </div>
+          <div class="metaCard">
           <span class="metaLabel">Current Focus</span>
-          <span class="metaValue">Hanoi-4 extension benchmark</span>
-        </div>
-        <div class="metaCard">
+          <span class="metaValue">Portability hardening and disciplined post-RC continuation</span>
+          </div>
+          <div class="metaCard">
           <span class="metaLabel">Current Build</span>
-          <span class="metaValue">0.10.0-beta.1</span>
-        </div>
-        <div class="metaCard">
+          <span class="metaValue">1.0.0-rc.1</span>
+          </div>
+          <div class="metaCard">
           <span class="metaLabel">Updated</span>
-          <span class="metaValue">March 21, 2026</span>
+          <span class="metaValue">May 4, 2026</span>
+          </div>
         </div>
-      </div>
       <div class="links">
         <a class="button" href="mmath-renovation.html">Project page</a>
         <a class="button" href="mmath-renovation-remote-experiments.html">Remote experiments guide</a>
@@ -369,12 +369,12 @@
         <p>`isbm` remains the strongest historical-control path, while the new `imbs-h1` analogue is the first explicit-`H` variant to materially improve its family.</p>
       </article>
 
-      <article class="step up_next">
+      <article class="step done">
         <div class="stepHeader">
-          <h2 class="stepTitle">Release Candidate Gate</h2>
-          <span class="badge">Up Next</span>
+          <h2 class="stepTitle">Release Candidate Baseline</h2>
+          <span class="badge">Completed</span>
         </div>
-        <p>Either reproduce a historically defensible `hanoi-4` success path, or document a convincing evidence-backed explanation for leaving it open.</p>
+        <p>The historical restoration baseline is now frozen at `1.0.0-rc.1`, with `hanoi-4` explicitly accepted as an explained-but-open extension benchmark for RC purposes.</p>
       </article>
 
       <article class="step up_next">
@@ -382,7 +382,7 @@
           <h2 class="stepTitle">1.0 Historical Baseline</h2>
           <span class="badge">Up Next</span>
         </div>
-        <p>Package the restored operator-style AbTweak environment, public validation story, and release-facing Pages summary as the first full baseline release.</p>
+        <p>Keep the RC baseline stable while supporting surfaces and post-RC research tracks continue toward the first full `1.0.0` historical baseline release.</p>
       </article>
     </section>
 
@@ -403,11 +403,11 @@
         </div>
         <div class="legendItem">
           <strong>Release Path</strong>
-          <span>Late beta now; move to release candidate only when the `hanoi-4` story is closed or convincingly explained.</span>
+          <span>`1.0.0-rc.1` is now the stable checkpoint; keep the RC baseline clean while supporting surfaces and post-RC tracks continue.</span>
         </div>
       </div>
       <p class="footer">
-        Latest checkpoint: <strong>Add imbs-h1 hanoi4 hierarchy analogue</strong>. Repository:
+        Latest checkpoint: <strong>1.0.0-rc.1 release-candidate freeze</strong>. Repository:
         <a href="https://github.com/sgwoods/mmath-renovation">sgwoods/mmath-renovation</a>
       </p>
     </section>

--- a/site/mmath-renovation-remote-experiments.html
+++ b/site/mmath-renovation-remote-experiments.html
@@ -251,12 +251,12 @@
                 </div>
                 <div class="metaCard">
                     <span class="metaLabel">Current focus</span>
-                    <span class="metaValue">Hanoi-4 support</span>
-                    <div class="metaNote">The strongest solve-oriented line remains `isbm + weak-POS + stack + Left-Wedge`.</div>
+                    <span class="metaValue">Portability hardening and disciplined post-RC continuation</span>
+                    <div class="metaNote">Curated remote runs now support the maintained `1.0.0-rc.1` baseline while the open Hanoi-4 lane stays clearly bounded.</div>
                 </div>
                 <div class="metaCard">
                     <span class="metaLabel">Updated</span>
-                    <span class="metaValue">March 22, 2026</span>
+                    <span class="metaValue">May 4, 2026</span>
                     <div class="metaNote">This guide is build-synced from the main repository.</div>
                 </div>
             </div>


### PR DESCRIPTION
Updates the repo-owned MMath public page sources to the current 1.0.0-rc.1 / post-RC state, switches the default public sync target to ~/Projects-All/public, and aligns the exported public manifest focus text with the current repo status.